### PR TITLE
Support for NEXT_REDIRECT exceptions

### DIFF
--- a/packages/zsa-react/src/index.ts
+++ b/packages/zsa-react/src/index.ts
@@ -98,7 +98,15 @@ export const useServerAction = <
 
       setIsExecuting(true)
 
-      const [data, err] = await serverAction(input)
+      let data, err;
+      
+      await serverAction(input).then(response => {
+        // during a NEXT_REDIRECT exception, response will not be defined,
+        // but technically the request was successful even though it threw an error.
+        if (response) {
+          [data, err] = response
+        }
+      })
 
       if (err) {
         if (opts?.onError) {

--- a/packages/zsa/src/zod-safe-function.ts
+++ b/packages/zsa/src/zod-safe-function.ts
@@ -619,6 +619,13 @@ export class ZodSafeFunction<
 
   /** helper function to handle errors with timeout checkpoints */
   public async handleError(err: any): Promise<[null, TZSAError]> {
+
+    // we need to throw any NEXT_REDIRECT errors so that next can
+    // properly handle them.
+    if (err.message === 'NEXT_REDIRECT') {
+      throw err;
+    }
+
     const customError =
       err instanceof ZSAError ? err : new ZSAError("ERROR", err)
 


### PR DESCRIPTION
when you call redirect() in a server action, this method throws an error of type NEXT_REDIRECT which means ZSA needs to just bubble that error up instead of catching it and wrapping it.  Currently ZSA catches it and the next.js framework doesn't redirect correctly.  This change also required a change to zsa-react because the response from the server action is undefined because we by-pass the ZSA logic.  So now we conditionally check if the response is set before trying to destruct the [data, err] array.