### PR TITLE
docs: Fix broken URL in documentation

### DIFF
--- a/packages/zsa/README.md
+++ b/packages/zsa/README.md
@@ -23,7 +23,7 @@ npm i zsa zsa-react zsa-react-query zsa-openapi zod
 
 ## Documentation
 
-View the full documentation and examples on [zsa.vercel.app](https://zsa.vercel.app/introduction).
+View the full documentation and examples on [zsa.vercel.app](https://zsa.vercel.app/docs/introduction).
 
 ## Support
 


### PR DESCRIPTION
Updated the URL from `https://zsa.vercel.app/introduction` to `https://zsa.vercel.app/docs/introduction` for correct redirection to the documentation introduction page.