### PR TITLE
adding support for a onFinish callback which is invoked after either …

### DIFF
--- a/examples/showcase/content/docs/use-server-action.mdx
+++ b/examples/showcase/content/docs/use-server-action.mdx
@@ -93,6 +93,9 @@ function MyComponent() {
     onStart: () => {
       console.log("Server action started")
     },
+    onFinish: () => {
+      console.log("Server action finished (invoked after onError/onSuccess)")
+    },
     initialData: {/* ... */},
     retry: {
       maxAttempts: 3,
@@ -118,6 +121,7 @@ function MyComponent() {
   - `onError`: A callback function to be called when the server action encounters an error. It receives an object with the `err` property containing the error.
   - `onSuccess`: A callback function to be called when the server action succeeds. It receives an object with the `data` property containing the returned data.
   - `onStart`: A callback function to be called when the server action starts executing.
+  - `onFinish`: A callback function to be called when the server action finishes executing, regardless of the outcome.
   - `initialData`: Initial data to be used as the `data` value before the server action is executed.
   - `retry`: An object specifying the retry behavior:
     - `maxAttempts`: The maximum number of retry attempts.

--- a/packages/zsa-react/src/index.ts
+++ b/packages/zsa-react/src/index.ts
@@ -28,6 +28,7 @@ export const useServerAction = <
       data: inferServerActionReturnData<TServerAction>
     }) => void
     onStart?: () => void
+    onFinish?: () => void
 
     initialData?: inferServerActionReturnData<TServerAction>
 
@@ -242,6 +243,7 @@ export const useServerAction = <
           data: resultRef.current.data as any,
         })
       }
+      opts?.onFinish?.()
     }
 
     // handle the error state
@@ -252,6 +254,7 @@ export const useServerAction = <
           err: resultRef.current.error as any,
         })
       }
+      opts?.onFinish?.()
     }
   }, [status, isPending])
 


### PR DESCRIPTION
adding support for a onFinish callback which is invoked after either onSuccess and onError for finally type of functionality.

The reason I'm adding this, is because in my own code I needed to disable / enable the ability for a user to close a sheet / drawer.  For example, this is what I'm doing in my app

```tsx
 const { execute, isPending } = useServerAction(createGroupAction, {
    retry: {
      maxAttempts: 3,
      delay: 2000,
    },
    onStart() {
      preventCloseRef.current = true;
    },
    onFinish() {
      preventCloseRef.current = false;
    },
    onError({ err }) {
      toast({
        title: "Something went wrong",
        description: err.message,
        variant: "destructive",
      });
    },
    onSuccess() {
      toast({
        title: "Group Created",
        description: "You can now start managing your events",
      });
      setIsOpen(false);
    },
  });
 ```
    
 Before adding this functionality, I had to copy the same line in both the onSuccess() and onError() callbacks.