### PR TITLE
Always return old data even when action has errors

### DIFF
--- a/.changeset/chatty-bugs-shout.md
+++ b/.changeset/chatty-bugs-shout.md
@@ -1,0 +1,7 @@
+---
+"zsa-react": patch
+"zsa": patch
+---
+
+Return submitted data to action when there is an error if createServerAction is
+confi1gured to do so with `persistedDataWhenError` option.

--- a/examples/showcase/content/docs/introduction.mdx
+++ b/examples/showcase/content/docs/introduction.mdx
@@ -14,7 +14,7 @@ _and much more!_
 
 To get started, you can install `zsa` using any package manager:
 
-```bash 
+```bash
 npm i zsa zsa-react zod
 ```
 
@@ -58,6 +58,10 @@ Let's break down the code:
   handler's input is does not match input schema.
 </Info>
 
+### createServerAction
+You can initialize a server action with the following options:
+  - `persistedDataWhenError` (optional, default: `false`)
+  It will persist the data when an error occurs. This is useful when you want to return the data even if an error occurs.
 ## Calling from the server
 
 Server actions can also be called directly from the server without the need for a try/catch block.

--- a/examples/showcase/content/docs/use-server-action.mdx
+++ b/examples/showcase/content/docs/use-server-action.mdx
@@ -72,7 +72,7 @@ import { useServerAction } from "zsa-react"
 import { myServerAction } from "./actions"
 
 function MyComponent() {
-  const { 
+  const {
     data,
     isPending,
     isOptimistic,
@@ -126,6 +126,9 @@ function MyComponent() {
   - `retry`: An object specifying the retry behavior:
     - `maxAttempts`: The maximum number of retry attempts.
     - `delay`: The delay in milliseconds between retry attempts, or a function that takes the current attempt number and error, and returns the delay.
+  - `persistedError`: When you want to persist the error state while the server action is pending. Default is `false`.
+  - `persistedData`: When you want to persist the data state while the server action is pending. Default is `false`. This is helpful if you have form fields that you want to keep filled even when there is an error on other fields.
+
 
 ## Return Value
 

--- a/packages/zsa-react/src/index.ts
+++ b/packages/zsa-react/src/index.ts
@@ -31,11 +31,14 @@ export const useServerAction = <
     onFinish?: (result: inferServerActionReturnType<TServerAction>) => void
 
     initialData?: inferServerActionReturnData<TServerAction>
-
     retry?: RetryConfig<TServerAction>
+    persistedError?: boolean
+    persistedData?: boolean
   }
 ) => {
   const initialData = opts?.initialData
+  const persistedError = opts?.persistedError ?? false
+  const persistedData = opts?.persistedData ?? false
 
   // store the result in state and a ref
   const [result, $setResult] = useState<TInnerResult<TServerAction>>(
@@ -144,7 +147,7 @@ export const useServerAction = <
         } else {
           setResult({
             error: err,
-            data: undefined,
+            data: persistedData ? data : undefined,
             status: "error",
           })
         }
@@ -327,6 +330,8 @@ export const useServerAction = <
     isPending,
     oldResult,
     result: resultRef.current,
+    persistedError,
+    persistedData,
   })
 
   return {

--- a/packages/zsa-react/src/results.ts
+++ b/packages/zsa-react/src/results.ts
@@ -88,16 +88,18 @@ export const calculateResultFromState = <
   isPending: boolean
   oldResult: TOldResult<TServerAction>
   result: TInnerResult<TServerAction>
+  persistedData?: boolean
+  persistedError?: boolean
 }): TServerActionResult<TServerAction> => {
-  const { isPending, oldResult, result } = state
+  const { isPending, oldResult, result, persistedData, persistedError } = state
 
   if (isPending && oldResult.status === "empty") {
     return {
       isPending: true,
       isOptimistic: false,
-      data: undefined,
+      data: persistedData ? result.data : undefined,
       isError: false,
-      error: undefined,
+      error: persistedError ? result.error : undefined,
       isSuccess: false,
       status: "pending",
     }
@@ -130,7 +132,7 @@ export const calculateResultFromState = <
     // error state
     return {
       isPending: false,
-      data: undefined,
+      data: persistedData ? result.data : undefined,
       isError: true,
       error: result.error as any,
       isOptimistic: false,

--- a/packages/zsa/src/procedure.ts
+++ b/packages/zsa/src/procedure.ts
@@ -62,7 +62,11 @@ export class CompleteProcedure<
   }
 
   /** make a server action with the current procedure */
-  createServerAction(): TZodSafeFunction<
+  createServerAction(
+    { persistedDataWhenError }: { persistedDataWhenError?: boolean } = {
+      persistedDataWhenError: false,
+    }
+  ): TZodSafeFunction<
     TInputSchema,
     undefined,
     TError,
@@ -82,6 +86,7 @@ export class CompleteProcedure<
       timeout: this.$internals.timeout,
       retryConfig: this.$internals.retryConfig,
       shapeErrorFns: this.$internals.shapeErrorFns,
+      persistedDataWhenError,
     }) as any
   }
 }

--- a/packages/zsa/src/types.ts
+++ b/packages/zsa/src/types.ts
@@ -335,6 +335,9 @@ export interface TInternals<
 
   /** A function to run when the handler errors to customize the error */
   shapeErrorFns: Array<TShapeErrorFn> | undefined
+
+  /** boolean indicating if the previous data is returned when there is an error **/
+  persistedDataWhenError?: boolean | undefined
 }
 
 export type InputTypeOptions = "formData" | "json" | "state"

--- a/tests/jest/__tests__/index.test.tsx
+++ b/tests/jest/__tests__/index.test.tsx
@@ -4,6 +4,7 @@
 import { cookies } from "next/headers"
 import {
   emptyFormDataAction,
+  emptyFormDataActionPreservingDataOnError,
   faultyAction,
   faultyOutputAction,
   faultyOutputInProcedureAction,
@@ -518,6 +519,19 @@ describe("actions", () => {
       const [data, err] = await emptyFormDataAction(formData)
 
       expect(data).toBeNull()
+      expect(err).not.toBeNull()
+      expect(err?.code).toBe(TEST_DATA.errors.inputParse)
+    })
+
+    it("returns data even when there is a error", async () => {
+      const formData = new FormData()
+      formData.append("wrong input", "hello world")
+      formData.append("avatar", new File([new Blob()], "avatar"))
+      const [data, err] =
+        await emptyFormDataActionPreservingDataOnError(formData)
+
+      expect(data).not.toBeNull()
+      expect(data?.avatar).toBeUndefined()
       expect(err).not.toBeNull()
       expect(err?.code).toBe(TEST_DATA.errors.inputParse)
     })

--- a/tests/jest/server/actions.ts
+++ b/tests/jest/server/actions.ts
@@ -18,6 +18,7 @@ import {
   protectedAction,
   protectedTimeoutAction,
   publicAction,
+  publicActionPreservingDataOnError,
   rateLimitedAction,
   redirectAction,
   retryAction,
@@ -463,6 +464,20 @@ export const emptyFormDataAction = publicAction
   .handler(async ({ input }) => {
     return input.value
   })
+
+const inputWithFile = z.object({
+  value: z.string(),
+  avatar: z.instanceof(File).optional(),
+})
+export const emptyFormDataActionPreservingDataOnError =
+  publicActionPreservingDataOnError
+    .input(inputWithFile.default({ value: "hello world" }), {
+      type: "formData",
+    })
+    .output(inputWithFile)
+    .handler(async ({ input }) => {
+      return input
+    })
 
 export const procedureChainAuthAction = setAuthToTwoProcedure
   .createServerAction()

--- a/tests/jest/server/procedures.ts
+++ b/tests/jest/server/procedures.ts
@@ -16,6 +16,9 @@ import { RetryState, TEST_DATA, auth, getPostById } from "./data"
  */
 
 export const publicAction = createServerAction()
+export const publicActionPreservingDataOnError = createServerAction({
+  persistedDataWhenError: true,
+})
 
 /**
  * Protected Action


### PR DESCRIPTION
# What?
This is useful if we use `data.my_field` in the UI. If other fields have errors but `my_field` is ok I want to keep showing it.

Fix this issue
https://github.com/IdoPesok/zsa/issues/121

## TODO
- [x] Keep data while executing the action
- [x] Keep errors while executing the action
- [x] Return data from action when there is an error (used in frontend to avoid ending with loss data)

## Current behavior

https://github.com/IdoPesok/zsa/assets/49499/2b3eea1a-c410-4f0f-bd3d-8b7b7bef627b


## With these changes
https://github.com/IdoPesok/zsa/assets/49499/e82058c6-22a1-4be1-ae5c-65359d1a3c06

