### PR TITLE
Updated Client Side Usage link typo in introduction.mdx

### DIFF
--- a/examples/showcase/content/docs/introduction.mdx
+++ b/examples/showcase/content/docs/introduction.mdx
@@ -176,5 +176,5 @@ Thats just the beginning... Continue reading to learn more about `zsa`!
 
 <Note>
   To use server actions for querying/refetching data from the client side, visit
-  the [Client Side Usage](/react-query) section.
+  the [Client Side Usage](/docs/react-query) section.
 </Note>


### PR DESCRIPTION
This PR updates the link to the 'Client Side Usage' section in the `introduction.mdx` file. 

The previous link was broken, leading to a 404 page. The new link directs users to the correct page.

Please review and merge if everything looks good.