### PR TITLE
Init executeRef also when executeFormAction is used

### DIFF
--- a/.changeset/sour-insects-provide.md
+++ b/.changeset/sour-insects-provide.md
@@ -1,0 +1,5 @@
+---
+"zsa-react": patch
+---
+
+Fix side effects not being called with execute form action

--- a/packages/zsa-react/src/index.ts
+++ b/packages/zsa-react/src/index.ts
@@ -213,6 +213,7 @@ export const useServerAction = <
         startTransition(() => {
           internalExecute(opts[0])
         })
+        executeRef.current = resolve
         resolve(null)
       })
     },


### PR DESCRIPTION
Without assigning the result of a resolved form action to the exectureRef the `onError` callback is not called