### PR TITLE
Server Action Routers

### DIFF
--- a/packages/zsa-react/src/index.ts
+++ b/packages/zsa-react/src/index.ts
@@ -2,9 +2,9 @@
 
 import { useCallback, useEffect, useRef, useState, useTransition } from "react"
 import {
-  TAnyServerActionRouterFn,
+  TAnyRouterAction,
   TAnyZodSafeFunctionHandler,
-  inferMapFromServerActionRouterFn,
+  inferMapFromRouterAction,
   inferServerActionReturnType,
 } from "zsa"
 import { TSetOptimisticInput, evaluateOptimisticInput } from "./optimistic"
@@ -24,9 +24,15 @@ export const useServerAction = <
   const TServerAction extends TAnyZodSafeFunctionHandler,
   TPersistError extends boolean = false,
   TPersistData extends boolean = false,
+  TUseRouterKey extends boolean = false,
 >(
   serverAction: TServerAction,
-  opts?: TUseServerActionOpts<TServerAction, TPersistError, TPersistData>
+  opts?: TUseServerActionOpts<
+    TServerAction,
+    TPersistError,
+    TPersistData,
+    TUseRouterKey
+  >
 ) => {
   const initialData = opts?.initialData
   const bindArgs = opts?.bind
@@ -347,24 +353,26 @@ export const useServerAction = <
   }
 }
 
-export const useServerActionRouter = <
-  TRouter extends TAnyServerActionRouterFn,
-  TServerActionKey extends keyof inferMapFromServerActionRouterFn<TRouter>,
+export const useRouterAction = <
+  TRouter extends TAnyRouterAction,
+  TServerActionKey extends keyof inferMapFromRouterAction<TRouter>,
   TPersistError extends boolean = false,
   TPersistData extends boolean = false,
 >(
   router: TRouter,
   serverActionKey: TServerActionKey,
   opts?: TUseServerActionOpts<
-    inferMapFromServerActionRouterFn<TRouter>[TServerActionKey],
+    inferMapFromRouterAction<TRouter>[TServerActionKey],
     TPersistError,
-    TPersistData
+    TPersistData,
+    false
   >
 ) => {
   const hookData = useServerAction<
-    inferMapFromServerActionRouterFn<TRouter>[TServerActionKey],
+    inferMapFromRouterAction<TRouter>[TServerActionKey],
     TPersistError,
-    TPersistData
+    TPersistData,
+    true
   >(router as any, {
     ...(opts || {}),
     routerKey: serverActionKey as string,

--- a/packages/zsa-react/src/opts.ts
+++ b/packages/zsa-react/src/opts.ts
@@ -10,6 +10,7 @@ export interface TUseServerActionOpts<
   TServerAction extends TAnyZodSafeFunctionHandler,
   TPersistError extends boolean,
   TPersistData extends boolean,
+  TUseRouterKey extends boolean,
 > {
   onError?: (args: { err: inferServerActionError<TServerAction> }) => void
   onSuccess?: (args: {
@@ -27,5 +28,5 @@ export interface TUseServerActionOpts<
   persistErrorWhilePending?: TPersistError
   persistDataWhilePending?: TPersistData
 
-  routerKey?: string
+  routerKey?: TUseRouterKey extends true ? string : undefined
 }

--- a/packages/zsa-react/src/opts.ts
+++ b/packages/zsa-react/src/opts.ts
@@ -1,0 +1,31 @@
+import {
+  TAnyZodSafeFunctionHandler,
+  inferServerActionError,
+  inferServerActionReturnData,
+  inferServerActionReturnType,
+} from "zsa"
+import { RetryConfig } from "./retries"
+
+export interface TUseServerActionOpts<
+  TServerAction extends TAnyZodSafeFunctionHandler,
+  TPersistError extends boolean,
+  TPersistData extends boolean,
+> {
+  onError?: (args: { err: inferServerActionError<TServerAction> }) => void
+  onSuccess?: (args: {
+    data: inferServerActionReturnData<TServerAction>
+  }) => void
+  onStart?: () => void
+  onFinish?: (result: inferServerActionReturnType<TServerAction>) => void
+
+  bind?: Parameters<TServerAction>[0] extends FormData
+    ? Parameters<TServerAction>[1]
+    : undefined
+
+  initialData?: inferServerActionReturnData<TServerAction>
+  retry?: RetryConfig<TServerAction>
+  persistErrorWhilePending?: TPersistError
+  persistDataWhilePending?: TPersistData
+
+  routerKey?: string
+}

--- a/packages/zsa/src/index.ts
+++ b/packages/zsa/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./errors"
 export * from "./procedure"
+export * from "./router"
 export * from "./types"
 export * from "./utils"
 export * from "./zod-safe-function"

--- a/packages/zsa/src/router.ts
+++ b/packages/zsa/src/router.ts
@@ -1,0 +1,70 @@
+import { TAnyZodSafeFunctionHandler } from "./types"
+import {
+  inferServerActionInput,
+  inferServerActionReturnType,
+} from "./zod-safe-function"
+
+interface TAnyActionMap {
+  [key: string]: TAnyZodSafeFunctionHandler
+}
+
+export interface TServerActionRouterFn<
+  TActionMap extends TAnyActionMap,
+  TActionKey extends keyof TActionMap,
+> {
+  (
+    key: TActionKey,
+    ...args: Parameters<TActionMap[TActionKey]>
+  ): Promise<ReturnType<TActionMap[TActionKey]>>
+}
+
+export type TAnyServerActionRouterFn = TServerActionRouterFn<any, any>
+
+type TOnStart<TActionMap extends TAnyActionMap> = {
+  [TOnStartKey in keyof TActionMap]: {
+    key: TOnStartKey
+    input: inferServerActionInput<TActionMap[TOnStartKey]>
+  }
+}[keyof TActionMap]
+
+type TOnComplete<TActionMap extends TAnyActionMap> = {
+  [TOnCompleteKey in keyof TActionMap]: {
+    key: TOnCompleteKey
+    input: inferServerActionInput<TActionMap[TOnCompleteKey]>
+    result: inferServerActionReturnType<TActionMap[TOnCompleteKey]>
+  }
+}[keyof TActionMap]
+
+/**
+ *  Create a router function from a map of actions
+ */
+export const createServerActionRouter = <
+  const TActionMap extends TAnyActionMap,
+>(
+  actionMap: TActionMap,
+  opts?: {
+    onStart?: (args: TOnStart<TActionMap>) => void
+    onComplete?: (args: TOnComplete<TActionMap>) => void
+  }
+): TServerActionRouterFn<TActionMap, keyof TActionMap> => {
+  const routerFn = async <TActionKey extends keyof TActionMap>(
+    key: TActionKey,
+    ...args: Parameters<TActionMap[TActionKey]>
+  ): Promise<ReturnType<TActionMap[TActionKey]>> => {
+    await opts?.onStart?.({ key, input: args[0] })
+
+    const action = actionMap[key]
+    // @ts-expect-error
+    const result = await action(...args)
+
+    await opts?.onComplete?.({ key, input: args[0], result: result as any })
+
+    // @ts-expect-error
+    return result
+  }
+
+  return routerFn
+}
+
+export type inferMapFromServerActionRouterFn<T> =
+  T extends TServerActionRouterFn<infer TActionMap, any> ? TActionMap : never

--- a/packages/zsa/src/router.ts
+++ b/packages/zsa/src/router.ts
@@ -1,20 +1,10 @@
 import { TAnyZodSafeFunctionHandler } from "./types"
-import {
-  inferServerActionError,
-  inferServerActionInput,
-  inferServerActionReturnData,
-  inferServerActionReturnType,
-} from "./zod-safe-function"
 
 interface TAnyActionMap {
   [key: string]: TAnyZodSafeFunctionHandler
 }
 
-interface TAnyRouterMap {
-  [key: string]: TAnyServerActionRouterFn
-}
-
-export interface TServerActionRouterFn<
+export interface TRouterAction<
   TActionMap extends TAnyActionMap,
   TActionKey extends keyof TActionMap,
 > {
@@ -24,84 +14,101 @@ export interface TServerActionRouterFn<
   ): Promise<ReturnType<TActionMap[TActionKey]>>
 }
 
-export type TAnyServerActionRouterFn = TServerActionRouterFn<any, any>
+export type TAnyRouterAction = TRouterAction<any, any>
 
-type TOnStart<TActionMap extends TAnyActionMap> = {
-  [TOnStartKey in keyof TActionMap]: {
-    key: TOnStartKey
-    input: inferServerActionInput<TActionMap[TOnStartKey]>
-  }
-}[keyof TActionMap]
+type TMergeActionMap<
+  T extends TAnyActionMap,
+  U extends TAnyActionMap,
+> = ServerActionRouter<T & U>
 
-type TOnError<TActionMap extends TAnyActionMap> = {
-  [TOnStartKey in keyof TActionMap]: {
-    key: TOnStartKey
-    input: inferServerActionInput<TActionMap[TOnStartKey]>
-    error: inferServerActionError<TActionMap[TOnStartKey]>
-  }
-}[keyof TActionMap]
+class ServerActionRouter<const TActionMap extends TAnyActionMap> {
+  $MAP: TActionMap
 
-type TOnSuccess<TActionMap extends TAnyActionMap> = {
-  [TOnStartKey in keyof TActionMap]: {
-    key: TOnStartKey
-    input: inferServerActionInput<TActionMap[TOnStartKey]>
-    data: inferServerActionReturnData<TActionMap[TOnStartKey]>
+  constructor(map: TActionMap) {
+    this.$MAP = map
   }
-}[keyof TActionMap]
 
-type TOnComplete<TActionMap extends TAnyActionMap> = {
-  [TOnCompleteKey in keyof TActionMap]: {
-    key: TOnCompleteKey
-    input: inferServerActionInput<TActionMap[TOnCompleteKey]>
-    result: inferServerActionReturnType<TActionMap[TOnCompleteKey]>
+  public add<
+    const TKey extends string,
+    const TAction extends TAnyZodSafeFunctionHandler,
+  >(
+    key: TKey,
+    action: TAction
+  ): TKey extends keyof TActionMap
+    ? `Duplicate key "${TKey}" found in router`
+    : TMergeActionMap<Record<TKey, TAction>, TActionMap> {
+    // @ts-expect-error
+    return new ServerActionRouter({
+      ...this.$MAP,
+      [key]: action,
+    })
   }
-}[keyof TActionMap]
+
+  public join<
+    const TJoinKey extends string,
+    const TRouter extends TAnyServerActionRouter,
+  >(
+    joinKey: TJoinKey,
+    router: TRouter
+  ): TJoinKey extends keyof TActionMap
+    ? `Duplicate key "${TJoinKey}" found in router`
+    : TMergeActionMap<inferJoinedMap<TRouter, TJoinKey>, TActionMap> {
+    const joinedMap: typeof router.$MAP = {}
+
+    for (const [key, value] of Object.entries(router.$MAP)) {
+      joinedMap[`${joinKey}.${key}`] = value
+    }
+
+    // @ts-expect-error
+    return new ServerActionRouter({
+      ...this.$MAP,
+      ...joinedMap,
+    })
+  }
+}
+
+type TAnyServerActionRouter = ServerActionRouter<any>
+
+type inferJoinedMap<
+  TRouter extends TAnyServerActionRouter,
+  TJoinKey extends string,
+> = {
+  [Key in Exclude<
+    keyof TRouter["$MAP"],
+    symbol
+  > as `${TJoinKey}.${Key}`]: TRouter["$MAP"][Key]
+}
 
 /**
  *  Create a router function from a map of actions
  */
-export const createServerActionRouter = <
-  const TActionMap extends TAnyActionMap,
+export const createServerActionRouter = () => new ServerActionRouter({})
+
+/**
+ *  Create a router function from a map of actions
+ */
+export const createRouterAction = <
+  const TRouter extends TAnyServerActionRouter,
 >(
-  actionMap: TActionMap,
-  opts?: {
-    onStart?: (args: TOnStart<TActionMap>) => void
-    onComplete?: (args: TOnComplete<TActionMap>) => void
-    onError?: (args: TOnError<TActionMap>) => void
-    onSuccess?: (args: TOnSuccess<TActionMap>) => void
-  }
-): TServerActionRouterFn<TActionMap, keyof TActionMap> => {
-  const routerFn = async <TActionKey extends keyof TActionMap>(
+  router: TRouter
+) => {
+  type TActionMap = TRouter["$MAP"]
+  const routerFn: TRouterAction<TActionMap, keyof TRouter["$MAP"]> = async <
+    TActionKey extends keyof TRouter,
+  >(
     /** The key of the action to execute */
     key: TActionKey,
     /** The input to the action */
     ...args: Parameters<TActionMap[TActionKey]>
   ): Promise<ReturnType<TActionMap[TActionKey]>> => {
-    await opts?.onStart?.({ key, input: args[0] })
-
-    const action = actionMap[key]
-    // @ts-expect-error
-    const result = await action(...args)
-
-    if (result) {
-      const [data, err] = result
-
-      if (err) {
-        await opts?.onError?.({ key, input: args[0], error: err })
-      } else {
-        await opts?.onSuccess?.({ key, input: args[0], data })
-      }
+    if (!router.$MAP[key]) {
+      throw new Error(`Action "${key as string}" not found in router`)
     }
-
-    await opts?.onComplete?.({ key, input: args[0], result: result as any })
-
-    // @ts-expect-error
-    return result
+    return await router.$MAP[key](...args)
   }
 
   return routerFn
 }
 
-export type inferMapFromServerActionRouterFn<
-  T extends TAnyServerActionRouterFn,
-> = T extends TServerActionRouterFn<infer TActionMap, any> ? TActionMap : never
+export type inferMapFromRouterAction<T extends TAnyRouterAction> =
+  T extends TRouterAction<infer TActionMap, any> ? TActionMap : never

--- a/packages/zsa/src/router.ts
+++ b/packages/zsa/src/router.ts
@@ -1,11 +1,17 @@
 import { TAnyZodSafeFunctionHandler } from "./types"
 import {
+  inferServerActionError,
   inferServerActionInput,
+  inferServerActionReturnData,
   inferServerActionReturnType,
 } from "./zod-safe-function"
 
 interface TAnyActionMap {
   [key: string]: TAnyZodSafeFunctionHandler
+}
+
+interface TAnyRouterMap {
+  [key: string]: TAnyServerActionRouterFn
 }
 
 export interface TServerActionRouterFn<
@@ -27,6 +33,22 @@ type TOnStart<TActionMap extends TAnyActionMap> = {
   }
 }[keyof TActionMap]
 
+type TOnError<TActionMap extends TAnyActionMap> = {
+  [TOnStartKey in keyof TActionMap]: {
+    key: TOnStartKey
+    input: inferServerActionInput<TActionMap[TOnStartKey]>
+    error: inferServerActionError<TActionMap[TOnStartKey]>
+  }
+}[keyof TActionMap]
+
+type TOnSuccess<TActionMap extends TAnyActionMap> = {
+  [TOnStartKey in keyof TActionMap]: {
+    key: TOnStartKey
+    input: inferServerActionInput<TActionMap[TOnStartKey]>
+    data: inferServerActionReturnData<TActionMap[TOnStartKey]>
+  }
+}[keyof TActionMap]
+
 type TOnComplete<TActionMap extends TAnyActionMap> = {
   [TOnCompleteKey in keyof TActionMap]: {
     key: TOnCompleteKey
@@ -45,10 +67,14 @@ export const createServerActionRouter = <
   opts?: {
     onStart?: (args: TOnStart<TActionMap>) => void
     onComplete?: (args: TOnComplete<TActionMap>) => void
+    onError?: (args: TOnError<TActionMap>) => void
+    onSuccess?: (args: TOnSuccess<TActionMap>) => void
   }
 ): TServerActionRouterFn<TActionMap, keyof TActionMap> => {
   const routerFn = async <TActionKey extends keyof TActionMap>(
+    /** The key of the action to execute */
     key: TActionKey,
+    /** The input to the action */
     ...args: Parameters<TActionMap[TActionKey]>
   ): Promise<ReturnType<TActionMap[TActionKey]>> => {
     await opts?.onStart?.({ key, input: args[0] })
@@ -56,6 +82,16 @@ export const createServerActionRouter = <
     const action = actionMap[key]
     // @ts-expect-error
     const result = await action(...args)
+
+    if (result) {
+      const [data, err] = result
+
+      if (err) {
+        await opts?.onError?.({ key, input: args[0], error: err })
+      } else {
+        await opts?.onSuccess?.({ key, input: args[0], data })
+      }
+    }
 
     await opts?.onComplete?.({ key, input: args[0], result: result as any })
 
@@ -66,5 +102,6 @@ export const createServerActionRouter = <
   return routerFn
 }
 
-export type inferMapFromServerActionRouterFn<T> =
-  T extends TServerActionRouterFn<infer TActionMap, any> ? TActionMap : never
+export type inferMapFromServerActionRouterFn<
+  T extends TAnyServerActionRouterFn,
+> = T extends TServerActionRouterFn<infer TActionMap, any> ? TActionMap : never


### PR DESCRIPTION
Problem: there is concern over accidentally exposing [unused server actions](https://github.com/vercel/next.js/issues/63804)

Solution: We can help mitigate risks here by adding routers which just expose one server action 😄 . You will only need to use "use server" in one file.

The idea is pretty simple, its just a map of keys -> actions. There is a bonus which you can join in routers together.

![Screen Shot 2024-07-07 at 11 26 22 PM](https://github.com/IdoPesok/zsa/assets/43461847/c161fd37-0cf3-4b2c-8de1-66b078840786)
![Screen Shot 2024-07-07 at 11 31 28 PM](https://github.com/IdoPesok/zsa/assets/43461847/7ef38f28-df54-4f14-a153-420cabdd9931)
