### PR TITLE
fix: return type of executeFormAction (Next 15)

### DIFF
--- a/packages/zsa-react/src/index.ts
+++ b/packages/zsa-react/src/index.ts
@@ -223,13 +223,13 @@ export const useServerAction = <
       ...opts: Parameters<TServerAction>[0] extends undefined
         ? []
         : [Parameters<TServerAction>[0]]
-    ): Promise<null> => {
+    ): Promise<void> => {
       return await new Promise((resolve) => {
         startTransition(() => {
           internalExecute(opts[0], bindArgs)
         })
         executeRef.current = resolve
-        resolve(null)
+        resolve()
       })
     },
     [internalExecute]


### PR DESCRIPTION
Next 15 complains, that `<form action={}>` should return `Promise<void>` whereas executeFormAction currently returns `Promise<null>`. As this function is only invoked in the above form context, I can't see any reason, why changing the actual return value (`resolve(void)` -> `resolve()`) could have any impact.

Tested it in our app freshly migrated to Next 15, and we couldn't trace any bugs yet with this fix in place.