### PR TITLE
docs: remove 'use server' from `procedures` documentation example.

### DIFF
--- a/examples/showcase/content/docs/procedures.mdx
+++ b/examples/showcase/content/docs/procedures.mdx
@@ -11,7 +11,6 @@ Procedures allow you to add additional context to a set of server actions, such 
 Here is an example of a simple procedure that ensures a user is logged in, and passes that information to the ctx of the handler
 
 ```ts title="actions.ts"
-"use server"
 import { createServerActionProcedure } from "zsa"
 
 


### PR DESCRIPTION
This will help users avoid running into the compilation error `A "use server" file can only export async functions, found object.`

Related to #169.